### PR TITLE
Add products_poc API specification

### DIFF
--- a/config.json
+++ b/config.json
@@ -154,6 +154,11 @@
               ]
             }
           ]
+        },
+        {
+          "service_name": "products_poc",
+          "content": "specs/products_poc.yaml",
+          "type": "oas3"
         }
       ]
     },

--- a/specs/products_poc.yaml
+++ b/specs/products_poc.yaml
@@ -1,0 +1,339 @@
+openapi: 3.0.1
+info:
+  title: products_controller
+  description: Controller for user and products
+  contact:
+    name: Fred
+    url: http://gigantic-server.com
+    email: prigogoi@cisco.com
+  license:
+    name: Apache 2.0
+    url: http://foo.bar
+  version: 40.0.0
+servers:
+  - url: http://localhost:8090/v1
+    description: Generated server url
+tags:
+  - name: User
+    description: Business User Services
+  - name: Sample Controller
+    description: Controller for sample operations
+paths:
+  /poc/users:
+    put:
+      tags:
+        - Sample Controller
+      summary: Update user
+      description: API used for updating user
+      operationId: updateUserById
+      requestBody:
+        description: Created user object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+            example:
+              firstName: John
+              lastName: Doe
+              email: john.doe@example.com
+        required: true
+      responses:
+        '204':
+          description: No content
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+        '400':
+          description: message
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericMessage'
+              example:
+                code: 500
+                message: Internal server error occurred
+    post:
+      tags:
+        - Sample Controller
+      summary: Save user information
+      description: API used for saving the users
+      operationId: createUser
+      requestBody:
+        description: Created user object
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+            example:
+              firstName: Jane
+              lastName: Smith
+              email: jane.smith@example.com
+        required: true
+      responses:
+        '200':
+          description: success
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericMessage'
+              example:
+                code: 200
+                message: User created successfully
+        '400':
+          description: message
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericMessage'
+              example:
+                code: 400
+                message: Invalid request parameters
+    delete:
+      tags:
+        - Sample Controller
+      summary: Delete user
+      description: API used for deleting users
+      operationId: deleteUserById
+      requestBody:
+        description: user id to delete
+        content:
+          application/json:
+            schema:
+              type: string
+              description: user id
+            example: user-123
+      responses:
+        '204':
+          description: no content
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericMessage'
+              example:
+                code: 204
+                message: User deleted successfully
+        '400':
+          description: message
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericMessage'
+              example:
+                code: 400
+                message: Invalid user ID format
+  /poc/secure/products:
+    get:
+      tags:
+        - Sample Controller
+      summary: Get products
+      description: Get information on product offerings
+      operationId: getSecureProducts
+      parameters:
+        - name: max
+          in: query
+          description: max param
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: success
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Link:
+              description: link
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecureProduct'
+              example:
+                products:
+                  - Product1
+                  - Product2
+                  - Product3
+        '400':
+          description: message
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecureProduct'
+              example:
+                products: []
+  /poc/ping:
+    get:
+      tags:
+        - Sample Controller
+      summary: API health check
+      description: API health check endpoint
+      operationId: ping
+      responses:
+        '200':
+          description: success
+          headers:
+            TrackingId:
+              description: tracking
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+            Date:
+              description: date
+              style: simple
+              schema:
+                allOf:
+                  - type: string
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: API is operational
+        default:
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericMessage'
+              example:
+                code: 500
+                message: Service unavailable
+components:
+  schemas:
+    User:
+      type: object
+      description: User model representing a system user
+      properties:
+        firstName:
+          type: string
+          description: User's first name
+        lastName:
+          type: string
+          description: User's last name
+        email:
+          type: string
+          description: User's email address
+    GenericMessage:
+      type: object
+      description: Standard response message for API operations
+      properties:
+        code:
+          type: integer
+          format: int32
+          description: Error code
+        message:
+          type: string
+          description: Error message
+    SecureProduct:
+      type: object
+      description: Container for product information
+      properties:
+        products:
+          type: array
+          items:
+            type: string
+          description: List of products


### PR DESCRIPTION
This PR adds the products_poc API specification, which includes:

1. New OpenAPI spec file in `specs/products_poc.yaml` 
2. Updated `config.json` to include the products_poc API in the navigation

The API includes endpoints for user management and product information.